### PR TITLE
Typos and punctuation fixes for overview page, register/authentication pages, and conda install page

### DIFF
--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -4,7 +4,7 @@
 
 All CLIMB-BIG-DATA resources are accessed via the Bryn web interface.
 
-You can login to Bryn at [https://bryn.climb.ac.uk/account/login/](https://bryn.climb.ac.uk/account/login/)
+You can login to Bryn [here](https://bryn.climb.ac.uk/account/login/).
 
 ## Two-factor authentication
 
@@ -54,13 +54,13 @@ Follow the link to 'setup your backup codes' as seen in the screenshot below:
 
 ![Backup codes link](img/bryn-2fa-success-backup-link.png){ width=600 }
 
-Next, hit the 'Generate tokens' button.
+Next, hit the 'Generate tokens' button:
 
 ![Generate tokens](img/bryn-generate-tokens.png){ width=600 }
 
 Print, save or otherwise make a note of these codes and keep them in a secure place.
 
-You can now proceed to the [Bryn dashboard](https://bryn.climb.ac.uk/)
+You can now proceed to the [Bryn dashboard](https://bryn.climb.ac.uk/).
 
 ### Logging in to Bryn after 2FA is set up
 
@@ -68,7 +68,7 @@ When you next login to Bryn, after entering your username and password, a token 
 
 ![Generate tokens](img/bryn-login-2fa.png){ width=350 }
 
-If you wish, mark the check box "Don't ask again on this device for 30 days"
+If you wish, mark the check box "Don't ask again on this device for 30 days".
 
 ### Using one of your backup tokens
 

--- a/docs/getting-started/how-to-register.md
+++ b/docs/getting-started/how-to-register.md
@@ -10,7 +10,7 @@ We divide users into three categories:
 
 Primary users should head over to the [Bryn registration page](https://bryn.climb.ac.uk/user/register/) to get started.
 
-To add secondary users to a team, please see [inviting users to your team]()
+To add secondary users to a team, please see [inviting users to your team]().
 
 <!-- prettier-ignore -->
 !!! warning
@@ -22,10 +22,10 @@ When you head over to the [Bryn registration page](https://bryn.climb.ac.uk/user
 
 ![Bryn registration form](img/bryn-registration-form.png){ width=650 }
 
-Accept the terms if you are happy, and you will then be asked information regarding your “Primary user details” including contact information and your position. You will also be asked about your “Team details” for your CLIMB-BIG-DATA team account. This includes information on where you currently work and why you would like to use CLIMBs resources.
+Accept the terms if you are happy, and you will then be asked information regarding your “Primary user details” including contact information and your position. You will also be asked about your “Team details” for your CLIMB-BIG-DATA team account. This includes information on where you currently work and why you would like to use CLIMB's resources.
 
 The registration request will be reviewed by a member of our management team. Please provide as much information as possible about your role and research to speed up the process. If we do not feel enough information has been provided, we may contact you. If your registration is successful, you will receive a verification email. Following verification, you will be taken to the [Bryn portal](https://bryn.climb.ac.uk/).
 
 <!-- prettier-ignore -->
 !!! warning
-    Please we aware that primary users will be provided to renew a group license every 3 months. For paying users, the length of a valid license period will be extended. If this license is not renewed, your access to resources will be blocked. You will be sent an email reminder for this.
+    Please be aware that primary users will be required to renew a group license every 3 months. For paying users, the length of a valid license period will be extended. If this license is not renewed, your access to resources will be blocked. You will be sent an email reminder for this.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ These docs are designed to help you get the best out of the CLIMB-BIG-DATA infra
 
 ### Getting started
 
-How to access CLIMB-BIG-DATA and find your way around via. the Bryn web interface.
+How to access CLIMB-BIG-DATA and find your way around via the Bryn web interface.
 
 [Registration](getting-started/how-to-register.md)  
 How to register and access CLIMB-BIG-DATA.
@@ -39,7 +39,7 @@ How to install software using Conda, in the context of a containerized environme
 How to use Nextflow with CLIMB-BIG-DATA.
 
 [Metagenomics walkthrough](walkthroughs/metagenomics-tutorial.md)
-A simple walk-through of some CLIMB-BIG-DATA functionality/
+A simple walk-through of some CLIMB-BIG-DATA functionality.
 
 [QIIME 2](walkthroughs/qiime2.md)
 How to install QIIME 2 on a notebook server and basic usage.

--- a/docs/notebook-servers/installing-software-with-conda.md
+++ b/docs/notebook-servers/installing-software-with-conda.md
@@ -9,7 +9,7 @@ $ conda info --envs
 base                     /opt/conda
 ```
 
-The base Conda env is installed at `/opt/conda`. Since we are running instide a container, any changes made to this part of the filesystem will not be retained once the container is stopped and restarted (unlike your home dir and shares, which are persisted).
+The base Conda env is installed at `/opt/conda`. Since we are running inside a container, any changes made to this part of the filesystem will not be retained once the container is stopped and restarted (unlike your home dir and shares, which are persisted).
 
 We've made the base environment read only to prevent any confustion.
 
@@ -38,7 +38,17 @@ Understanding the above, you can create new Conda environments in the usual way.
 
 Lets go ahead and install [bactopia](https://bactopia.github.io/v2.2.0/quick-start/) as an example.
 
-If you try listing channels, you'll see you already have conda-forge and bioconda set.
+If you try listing channels, you'll see you already have `conda-forge` and `bioconda` set:
+
+```console
+jovyan:~$ conda config --show channels
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+```
+
+Now, lets install `bactopia`:
 
 ```console
 jovyan:~$ conda create -y -n bactopia bactopia ipykernel
@@ -68,7 +78,7 @@ base                     /opt/conda
 bactopia                 /shared/team/conda/demouser.andy-bryn-dev-t/bactopia
 ```
 
-And finally lets activate the environment
+And finally, lets activate the environment:
 
 ```console
 jovyan:~$ conda activate bactopia


### PR DESCRIPTION
- Fixed typos in the 'Overview' page.
- Fixed typos and punctuation in 'How to Register' and 'Authentication' pages.
- Fixed typos and added conda example for 'Installing software with Conda' page. 